### PR TITLE
[fix] #9 - Reading Gauge32 type OID returns nil

### DIFF
--- a/lib/netsnmp/varbind.rb
+++ b/lib/netsnmp/varbind.rb
@@ -71,7 +71,7 @@ module NETSNMP
       when OpenSSL::BN
       else
        asn_value # assume it's already primitive
-      end 
+      end
     end
 
     def convert_to_asn(typ, value)
@@ -80,15 +80,19 @@ module NETSNMP
       if typ.is_a?(Symbol)
         asn_type = case typ
           when :ipaddress then 0
-          when :counter32 then 1
-          when :gauge then 2
+          when :counter32
+            asn_val = [value].pack("n*")
+            1
+          when :gauge
+            asn_val = [value].pack("n*")
+            2
           when :timetick
             return Timetick.new(value).to_asn
           when :opaque then 4
           when :nsap then 5
           when :counter64 then 6
           when :uinteger then 7
-          else  
+          else
             raise Error, "#{typ}: unsupported application type"
         end
       end
@@ -102,6 +106,7 @@ module NETSNMP
         when 1 # ASN counter 32
           asn.value.unpack("n*")[0] || 0
         when 2 # gauge
+          asn.value.unpack("n*")[0] || 0
         when 3 # timeticks
           Timetick.new(asn.value.unpack("N*")[0] || 0)
         when 4 # opaque

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@ require 'simplecov' if ENV["COVERAGE"]
 require 'coveralls'
 Coveralls.wear!
 
-SimpleCov.start do   
+SimpleCov.start do
   minimum_coverage 85
   add_filter ".bundle"
   add_filter "/spec/"

--- a/spec/varbind_spec.rb
+++ b/spec/varbind_spec.rb
@@ -15,6 +15,16 @@ RSpec.describe NETSNMP::Varbind do
       end
       context "when passed a type" do
         # TODO: tidy this for IP Addresses
+        it "converts gauge32" do
+          gauge = 805
+          varbind = described_class.new(".1.3.6.1.2.1.1.3.0", type: :gauge, value: gauge)
+          expect(varbind.to_der).to end_with("B\x02\x03%".b)
+        end
+        it "converts counter32" do
+          gauge = 998932
+          varbind = described_class.new(".1.3.6.1.2.1.1.3.0", type: :counter32, value: gauge)
+          expect(varbind.to_der).to end_with("A\x02>\x14".b)
+        end
         it "converts integer ticks" do
           timetick = 1
           varbind = described_class.new(".1.3.6.1.2.1.1.3.0", type: :timetick, value: timetick)


### PR DESCRIPTION
With this fix I was able to read the same Gauge32 value using the library and using snmpwalk:

```
$ snmpwalk -c public -v1 10.81.35.130 .1.3.6.1.2.1.17.7.1.4.5.1.1.1
BRIDGE-MIB::dot1dBridge.7.1.4.5.1.1.1 = Gauge32: 805
```

Test ruby code:

```
require 'netsnmp'

manager = NETSNMP::Client.new(host: "10.81.35.130", port: 161, community: "public",
                              timeout: 30, version: "1")

value = manager.get(oid: ".1.3.6.1.2.1.17.7.1.4.5.1.1.1")
puts "Value: [#{value}]"
puts value.inspect

manager.close
```

Test result:

```
$ ruby test.rb
Value: [805]
805
```