### PR TITLE
snmp v3 pdu size

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,4 +20,4 @@ end
 
 gem "xorcist"
 
-gem "rubocop", require: false
+gem "rubocop", "0.52.1", require: false

--- a/lib/netsnmp/encryption/aes.rb
+++ b/lib/netsnmp/encryption/aes.rb
@@ -15,7 +15,7 @@ module NETSNMP
 
         cipher.encrypt
         cipher.iv = iv
-        cipher.key = des_key
+        cipher.key = aes_key
 
         if (diff = decrypted_data.length % 8) != 0
           decrypted_data << ("\x00" * (8 - diff))
@@ -29,7 +29,6 @@ module NETSNMP
 
       def decrypt(encrypted_data, salt:, engine_boots:, engine_time:)
         raise Error, "invalid priv salt received" unless (salt.length % 8).zero?
-        raise Error, "invalid encrypted PDU received" unless (encrypted_data.length % 8).zero?
 
         cipher = OpenSSL::Cipher::AES128.new(:CFB)
         cipher.padding = 0
@@ -37,7 +36,7 @@ module NETSNMP
         iv = generate_decryption_key(engine_boots, engine_time, salt)
 
         cipher.decrypt
-        cipher.key = des_key
+        cipher.key = aes_key
         cipher.iv = iv
         decrypted_data = cipher.update(encrypted_data) + cipher.final
         NETSNMP.debug { "decrypted:\n#{Hexdump.dump(decrypted_data)}" }
@@ -76,7 +75,7 @@ module NETSNMP
          0xff &  time].pack("c*") + salt
       end
 
-      def des_key
+      def aes_key
         @priv_key[0, 16]
       end
     end

--- a/lib/netsnmp/encryption/des.rb
+++ b/lib/netsnmp/encryption/des.rb
@@ -30,7 +30,6 @@ module NETSNMP
 
       def decrypt(encrypted_data, salt:, **)
         raise Error, "invalid priv salt received" unless (salt.length % 8).zero?
-        raise Error, "invalid encrypted PDU received" unless (encrypted_data.length % 8).zero?
 
         cipher = OpenSSL::Cipher::DES.new(:CBC)
         cipher.padding = 0

--- a/lib/netsnmp/encryption/des.rb
+++ b/lib/netsnmp/encryption/des.rb
@@ -30,6 +30,7 @@ module NETSNMP
 
       def decrypt(encrypted_data, salt:, **)
         raise Error, "invalid priv salt received" unless (salt.length % 8).zero?
+        raise Error, "invalid encrypted PDU received" unless (encrypted_data.length % 8).zero?
 
         cipher = OpenSSL::Cipher::DES.new(:CBC)
         cipher.padding = 0


### PR DESCRIPTION
According to the SNMPv3 Standard for AES128 the encrypted data does not necessarily needs to be a multiplier of 8.
The check causes issues with some device types.
Technically checking for a modulo of 4 would work when you check the packet definition, but if it's not correct an error should be thrown later.
https://tools.ietf.org/html/rfc3826#section-3.2.4.2
```
      statusInformation =
        decryptData(
        IN    decryptKey               -- secret key for decryption
        IN    privParameters           -- as received on the wire
        IN    encryptedData            -- encrypted data (encryptedPDU)
        OUT   decryptedData            -- decrypted data (scopedPDU)
              )

   The abstract data elements are:

   statusInformation
      An indication of whether the data was successfully decrypted, and
      if not, an indication of the error.

   decryptKey
      The secret key to be used by the decryption algorithm.  The length
      of this key MUST be 16 octets.

   privParameters
      The 64-bit integer to be used to calculate the IV.

   encryptedData
      The data to be decrypted.

   decryptedData
      The decrypted data.
```