### PR TITLE
remove support for deprecated ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ script:
 
 language: ruby
 rvm:
-  - 2.1
-  - 2.2
   - 2.3
   - 2.4
   - 2.5

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ All of these issues are resolved here.
 * Client Interface, which supports SNMP v3, v2c, and v1
 * Supports get, getnext, set and walk calls.
 * Proxy IO object support (for eventmachine/celluloid-io)
-* Ruby >= 2.1 support (modern)
+* Ruby >= 2.3 support (modern)
 * Pure Ruby (no FFI)
 
 ## Examples


### PR DESCRIPTION
Ruby 2.1 is deprecated since one year, Ruby 2.2 will be deprecated from next weekend on.
I think supporting old ruby versions is not necessary.