### PR TITLE
Pad gauge and counter values correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,6 @@ sudo: required
 services:
   - docker
 
-before_install:
-  - sudo apt-add-repository multiverse 
-  - sudo apt-get update
-  - sudo apt-get install -o Dpkg::Options::="--force-confold" --force-yes -y docker-ce
-
 install:
   - gem i rubygems-update -v '<3' && update_rubygems
   - bundle install --path .bundle

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,10 @@ rvm:
   - 2.6
   - ruby-head
   - jruby-head
-  - rbx-2
+  - truffleruby
 matrix:
   allow_failures:
   - rvm: ruby-head
   - rvm: jruby-head
     # to figure out later
-  - rvm: rbx-2
+  - rvm: truffleruby

--- a/lib/netsnmp/varbind.rb
+++ b/lib/netsnmp/varbind.rb
@@ -81,11 +81,11 @@ module NETSNMP
                    when :ipaddress then 0
                    when :counter32
                      asn_val = [value].pack("N*")
-                     asn_val = asn_val[1..-1] while asn_val[0] == "\x00".b && asn_val[1].unpack('B').first != '1'
+                     asn_val = asn_val[1..-1] while asn_val[0] == "\x00".b && asn_val[1].unpack("B").first != "1"
                      1
                    when :gauge
                      asn_val = [value].pack("N*")
-                     asn_val = asn_val[1..-1] while asn_val[0] == "\x00".b && asn_val[1].unpack('B').first != '1'
+                     asn_val = asn_val[1..-1] while asn_val[0] == "\x00".b && asn_val[1].unpack("B").first != "1"
                      2
                    when :timetick
                      return Timetick.new(value).to_asn

--- a/lib/netsnmp/varbind.rb
+++ b/lib/netsnmp/varbind.rb
@@ -81,11 +81,11 @@ module NETSNMP
                    when :ipaddress then 0
                    when :counter32
                      asn_val = [value].pack("N*")
-                     asn_val = asn_val[1..-1] while asn_val.start_with?("\x00")
+                     asn_val = asn_val[1..-1] while asn_val[0] == "\x00".b && asn_val[1].unpack('B').first != '1'
                      1
                    when :gauge
                      asn_val = [value].pack("N*")
-                     asn_val = asn_val[1..-1] while asn_val.start_with?("\x00")
+                     asn_val = asn_val[1..-1] while asn_val[0] == "\x00".b && asn_val[1].unpack('B').first != '1'
                      2
                    when :timetick
                      return Timetick.new(value).to_asn

--- a/spec/varbind_spec.rb
+++ b/spec/varbind_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe NETSNMP::Varbind do
           # Type: Integer
           expect(header[3..-1].to_i(2)).to eq(2)
           # Length & Value
-          expect(varbind.to_der).to end_with("\x03\x00\x03%".b)
+          expect(varbind.to_der).to end_with("\x02\x03%".b)
 
           # Original Value
           asn = varbind.to_asn.value.last


### PR DESCRIPTION
This addresses #27 

~Gauges are signed, where counters are unsigned, and should be handled differently.~ Gauges and counters should be padded correctly so that their positive values aren't interpreted as negative.