### PR TITLE
Fix Timetick's bug when bytesize < 4

### DIFF
--- a/lib/netsnmp/varbind.rb
+++ b/lib/netsnmp/varbind.rb
@@ -118,7 +118,9 @@ module NETSNMP
         val.prepend("\x00") while val.bytesize < 4
         val.unpack("N*")[0] || 0
       when 3 # timeticks
-        Timetick.new(asn.value.unpack("N*")[0] || 0)
+        val = asn.value
+        val.prepend("\x00") while val.bytesize < 4
+        Timetick.new(val.unpack("N*")[0] || 0)
         # when 4 # opaque
         # when 5 # NSAP
       when 6 # ASN Counter 64


### PR DESCRIPTION
In some cases when my Network Devices were recently restarted they would send an uptime with a timeticks of less than 4 bytes.