### PR TITLE
WIP - fix: Ensure that the response matches the request

### DIFF
--- a/lib/netsnmp/session.rb
+++ b/lib/netsnmp/session.rb
@@ -38,7 +38,14 @@ module NETSNMP
     def send(pdu)
       encoded_request = encode(pdu)
       encoded_response = @transport.send(encoded_request)
-      decode(encoded_response)
+      response = decode(encoded_response)
+
+      tries = 0
+      while response.request_id != pdu.request_id && tries < 3 do
+        response = decode(@transport.recv)
+        tries = tries + 1
+      end
+      response
     end
 
     private


### PR DESCRIPTION
@HoneyryderChuck We have a device that seems to be misbehaving, and not sending responses correctly.

This change ensures that the matching response is sent back for a request. I'm not sure it's entirely the correct fix, but it works :)

Before. Notice the mismatched ids in the request / response pairs below:

```
#<NETSNMP::PDU:0x000000024f98c0 @version=1, @community="nsSNMPwr", @error_status=0, @error_index=0, @type=1, @varbinds=[#<NETSNMP::Varbind:0x000000024f9668 @oid="1.3.6.1.4.1.34592.1.5.1.1.2.18.1", @type=nil>], @request_id=1696733791>
#<NETSNMP::PDU:0x000000024f0c70 @version=1, @community="nsSNMPwr", @error_status=0, @error_index=0, @type=2, @varbinds=[#<NETSNMP::Varbind:0x000000024f0a40 @oid="1.3.6.1.4.1.34592.1.5.1.1.2.18.1.1.2.1.0.1.1", @type=nil, @value=1>], @request_id=1696733791>

#<NETSNMP::PDU:0x000000024eb180 @version=1, @community="nsSNMPwr", @error_status=0, @error_index=0, @type=1, @varbinds=[#<NETSNMP::Varbind:0x000000024eade8 @oid="1.3.6.1.4.1.34592.1.5.1.1.2.18.1.1.2.1.0.1.1", @type=nil>], @request_id=612776637>
#<NETSNMP::PDU:0x000000024e24b8 @version=1, @community="nsSNMPwr", @error_status=0, @error_index=0, @type=2, @varbinds=[#<NETSNMP::Varbind:0x000000024e20f8 @oid="1.3.6.1.4.1.34592.1.5.1.1.2.18.1.1.2.1.0.1.1", @type=nil, @value=1>], @request_id=1696733791>

#<NETSNMP::PDU:0x000000024db398 @version=1, @community="nsSNMPwr", @error_status=0, @error_index=0, @type=1, @varbinds=[#<NETSNMP::Varbind:0x000000024db190 @oid="1.3.6.1.4.1.34592.1.5.1.1.2.18.1", @type=nil>], @request_id=1579350665>
#<NETSNMP::PDU:0x00000001ec3460 @version=1, @community="nsSNMPwr", @error_status=0, @error_index=0, @type=2, @varbinds=[#<NETSNMP::Varbind:0x00000001ec25d8 @oid="1.3.6.1.4.1.34592.1.5.1.1.2.18.1.1.2.1.0.1.2", @type=nil, @value=1>], @request_id=612776637>

#<NETSNMP::PDU:0x00000001e831a8 @version=1, @community="nsSNMPwr", @error_status=0, @error_index=0, @type=1, @varbinds=[#<NETSNMP::Varbind:0x00000001e82c30 @oid="1.3.6.1.4.1.34592.1.5.1.1.2.18.1.1.2.1.0.1.2", @type=nil>], @request_id=2042539484>
#<NETSNMP::PDU:0x00000001e6ba80 @version=1, @community="nsSNMPwr", @error_status=0, @error_index=0, @type=2, @varbinds=[#<NETSNMP::Varbind:0x00000001e6b210 @oid="1.3.6.1.4.1.34592.1.5.1.1.2.18.1.1.2.1.0.1.1", @type=nil, @value=1>], @request_id=1579350665>

#<NETSNMP::PDU:0x00000001e1b2d8 @version=1, @community="nsSNMPwr", @error_status=0, @error_index=0, @type=1, @varbinds=[#<NETSNMP::Varbind:0x00000001e1ab58 @oid="1.3.6.1.4.1.34592.1.5.1.1.2.18.1.1.2.1.0.1.1", @type=nil>], @request_id=1417807572>
#<NETSNMP::PDU:0x00000001def570 @version=1, @community="nsSNMPwr", @error_status=0, @error_index=0, @type=2, @varbinds=[#<NETSNMP::Varbind:0x00000001deee18 @oid="1.3.6.1.4.1.34592.1.5.1.1.2.18.1.1.2.1.0.1.2", @type=nil, @value=1>], @request_id=612776637>
```

After:

```
#<NETSNMP::PDU:0x0000000297fea8 @version=1, @community="nsSNMPwr", @error_status=0, @error_index=0, @type=1, @varbinds=[#<NETSNMP::Varbind:0x0000000297f778 @oid="1.3.6.1.4.1.34592.1.5.1.1.2.18.1", @type=nil>], @request_id=1772146288>
#<NETSNMP::PDU:0x000000029769c0 @version=1, @community="nsSNMPwr", @error_status=0, @error_index=0, @type=2, @varbinds=[#<NETSNMP::Varbind:0x00000002975a98 @oid="1.3.6.1.4.1.34592.1.5.1.1.2.18.1.1.2.1.0.1.1", @type=nil, @value=1>], @request_id=1772146288>

#<NETSNMP::PDU:0x0000000294b298 @version=1, @community="nsSNMPwr", @error_status=0, @error_index=0, @type=1, @varbinds=[#<NETSNMP::Varbind:0x0000000294ade8 @oid="1.3.6.1.4.1.34592.1.5.1.1.2.18.1.1.2.1.0.1.1", @type=nil>], @request_id=1232094884>
#<NETSNMP::PDU:0x00000002944268 @version=1, @community="nsSNMPwr", @error_status=0, @error_index=0, @type=2, @varbinds=[#<NETSNMP::Varbind:0x00000002943f98 @oid="1.3.6.1.4.1.34592.1.5.1.1.2.18.1.1.2.1.0.1.2", @type=nil, @value=1>], @request_id=1232094884>

#<NETSNMP::PDU:0x00000002941a40 @version=1, @community="nsSNMPwr", @error_status=0, @error_index=0, @type=1, @varbinds=[#<NETSNMP::Varbind:0x00000002941310 @oid="1.3.6.1.4.1.34592.1.5.1.1.2.18.1.1.2.1.0.1.2", @type=nil>], @request_id=1944901503>
#<NETSNMP::PDU:0x00000002930600 @version=1, @community="nsSNMPwr", @error_status=0, @error_index=0, @type=2, @varbinds=[#<NETSNMP::Varbind:0x0000000292f070 @oid="1.3.6.1.4.1.34592.1.5.1.1.2.18.1.1.2.1.0.1.3", @type=nil, @value=1>], @request_id=1944901503>

#<NETSNMP::PDU:0x00000002923108 @version=1, @community="nsSNMPwr", @error_status=0, @error_index=0, @type=1, @varbinds=[#<NETSNMP::Varbind:0x00000002921718 @oid="1.3.6.1.4.1.34592.1.5.1.1.2.18.1.1.2.1.0.1.3", @type=nil>], @request_id=1401972863>
#<NETSNMP::PDU:0x000000027d6e30 @version=1, @community="nsSNMPwr", @error_status=0, @error_index=0, @type=2, @varbinds=[#<NETSNMP::Varbind:0x000000027d5ee0 @oid="1.3.6.1.4.1.34592.1.5.1.1.2.18.1.1.2.1.0.1.4", @type=nil, @value=1>], @request_id=1401972863>

#<NETSNMP::PDU:0x000000027cc548 @version=1, @community="nsSNMPwr", @error_status=0, @error_index=0, @type=1, @varbinds=[#<NETSNMP::Varbind:0x000000027cbd00 @oid="1.3.6.1.4.1.34592.1.5.1.1.2.18.1.1.2.1.0.1.4", @type=nil>], @request_id=1898492411>
#<NETSNMP::PDU:0x0000000279eee0 @version=1, @community="nsSNMPwr", @error_status=0, @error_index=0, @type=2, @varbinds=[#<NETSNMP::Varbind:0x00000002792f28 @oid="1.3.6.1.4.1.34592.1.5.1.1.2.18.1.1.2.1.0.1.5", @type=nil, @value=1>], @request_id=1898492411>

#<NETSNMP::PDU:0x00000002782ee8 @version=1, @community="nsSNMPwr", @error_status=0, @error_index=0, @type=1, @varbinds=[#<NETSNMP::Varbind:0x00000002782560 @oid="1.3.6.1.4.1.34592.1.5.1.1.2.18.1.1.2.1.0.1.5", @type=nil>], @request_id=1938472559>
#<NETSNMP::PDU:0x000000027292f8 @version=1, @community="nsSNMPwr", @error_status=0, @error_index=0, @type=2, @varbinds=[#<NETSNMP::Varbind:0x0000000271fa28 @oid="1.3.6.1.4.1.34592.1.5.1.1.2.18.1.1.2.1.0.1.6", @type=nil, @value=1>], @request_id=1938472559>

etc...
```