### PR TITLE
Parse the last 4 bytes of an int instead of the first 4

### DIFF
--- a/lib/netsnmp/varbind.rb
+++ b/lib/netsnmp/varbind.rb
@@ -114,13 +114,9 @@ module NETSNMP
         IPAddr.new_ntoh(asn.value)
       when 1, # ASN counter 32
            2 # gauge
-        val = asn.value
-        val.prepend("\x00") while val.bytesize < 4
-        val.unpack("N*")[0] || 0
+        unpack_32_bit_int(asn.value)
       when 3 # timeticks
-        val = asn.value
-        val.prepend("\x00") while val.bytesize < 4
-        Timetick.new(val.unpack("N*")[0] || 0)
+        Timetick.new(unpack_32_bit_int(asn.value))
         # when 4 # opaque
         # when 5 # NSAP
       when 6 # ASN Counter 64
@@ -129,6 +125,12 @@ module NETSNMP
         val.unpack("NNNN").reduce(0) { |sum, elem| (sum << 32) + elem }
         # when 7 # ASN UInteger
       end
+    end
+
+    def unpack_32_bit_int(val)
+      val.prepend("\x00") while val.bytesize < 4
+      directive = "@#{val.bytesize - 4}N*"
+      val.unpack(directive)[0] || 0
     end
   end
 end


### PR DESCRIPTION
Hi!

We have encountered odd behaviour with some timetick values, where the supposedly 4-byte value of ASN1Data might be 5 bytes long when it hits the `convert_application_asn` method in `varbind.rb`, padded by zeroes (before the `prepend`).

The root cause of this is unknown to me, but we've fixed it by letting the `unpack` method parse the last 4 bytes instead of the first 4.

An example:

1. `asn.value` is `\x00\x0eI\x9bF` (`.bytesize` of 5)
2. `unpack("N*")` parses the first 4 bytes to 936347

Fixed by:

2. `unpack("@1N*")` parses the last 4 bytes, skipping 1 in the beginning, to 239704902

I've also applied this to the other `N*`-parsing, as I suspect it should be using similar rules.

We've been running this fix for a couple of weeks now and haven't noticed any side effects.

As a side note, Python's `int.from_bytes` parses `\x00\x0eI\x9bF` "correctly" (`int.from_bytes(b'\x00\x0eI\x9bF', "big")`), maybe it also parses the last 4 bytes?