### PR TITLE
Fix bug on security_level when an extra byte is sent

### DIFF
--- a/lib/netsnmp/message.rb
+++ b/lib/netsnmp/message.rb
@@ -35,7 +35,8 @@ module NETSNMP
       _, _, message_flags, = headers.value
 
       # get last byte
-      security_level = message_flags.with_label(:message_flags).value.unpack("C*").last
+      # discard the left-outermost bits and keep the remaining two
+      security_level = message_flags.with_label(:message_flags).value.unpack("C*").last & 3
 
       sec_params_asn = OpenSSL::ASN1.decode(sec_params.value).with_label(:security_params)
 


### PR DESCRIPTION
For an unknown reason Cisco ASA send an extra byte on the security level

We have security_level: 8 instead of 0 and 9 instead of 1

I added a '%8' on the security_level to fix this
