### PR TITLE
Do not convert string encoding, figure out hex strings

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -18,6 +18,9 @@ Metrics/AbcSize:
 Metrics/ClassLength:
   Max: 1000
 
+Metrics/ModuleLength:
+  Max: 1000
+
 # Offense count: 8
 Metrics/CyclomaticComplexity:
   Max: 20

--- a/lib/netsnmp/extensions.rb
+++ b/lib/netsnmp/extensions.rb
@@ -93,16 +93,21 @@ module NETSNMP
     end
   end
 
-  unless defined?(Hexdump) # support the hexdump gem
-    module Hexdump
-      using StringExtensions
+  module Hexdump
+    using StringExtensions
 
-      def self.dump(data, width: 8, separator: "\n")
-        pairs = data.unpack1("H*").scan(/.{4}/)
-        pairs.each_slice(width).map do |row|
-          row.join(" ")
-        end.join(separator)
-      end
+    def self.dump(data, width: 8, in_groups_of: 4, separator: "\n")
+      pairs = data.unpack1("H*").scan(/.{#{in_groups_of}}/)
+      pairs.each_slice(width).map do |row|
+        row.join(" ")
+      end.join(separator)
+    end
+  end
+
+  # Like a string, but it prints an hex-string version of itself
+  class HexString < String
+    def inspect
+      Hexdump.dump(self, in_groups_of: 2, separator: " ")
     end
   end
 end

--- a/sig/mib.rbs
+++ b/sig/mib.rbs
@@ -1,5 +1,8 @@
 module NETSNMP
   module MIB
+    type import = {ids: Array[{name: string}], name: string} | {ids: {name: string}, name: string}
+
+
     MIBDIRS: Array[String]
     PARSER: Parser
 
@@ -12,7 +15,7 @@ module NETSNMP
 
     def self?.load: (String mod) -> void
 
-    def self?.load_imports: (?Hash[Symbol, untyped] data) -> Hash[String, Array[String]]?
+    def self?.load_imports: ((Array[import] | import)? data) -> Hash[String, Array[String]]?
     def self?.load_defaults: () -> void
   end
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -67,6 +67,24 @@ RSpec.describe NETSNMP::Client do
         WALK
       end
       let(:set_oid_result) { 43 }
+
+      context "when the returned value is a hex-string" do
+        let(:protocol_options) do
+          {
+            version: "2c",
+            community: "foreignformats/winxp1"
+          }
+        end
+        let(:hex_get_oid) { "1.3.6.1.2.1.25.3.7.1.3.10.1" }
+        let(:hex_get_result) { "\x01\x00\x00\x00" }
+        let(:hex_get_output) { "01 00 00 00" }
+        let(:value) { subject.get(oid: hex_get_oid) }
+
+        it "returns the string, which outputs the hex-representation" do
+          expect(value).to eq(hex_get_result)
+          expect(value.inspect).to include(hex_get_output)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Do not rely on converstion to utf-8. Instead, to figure out whether it's an hex-string, find out whether there's a character which isn't printable. The strategy is the same that netsnmp uses, except that here we resort to regexes, whereas they use libc functions like `isprint` and `isspace`.

This PR also fixes MIB parsing when value translation needs to be delayed due to one of the identifiers being defined below in the same file.

Closes #41 