### PR TITLE
Raise an authorization error when a wrong password is set

### DIFF
--- a/lib/netsnmp/pdu.rb
+++ b/lib/netsnmp/pdu.rb
@@ -37,6 +37,9 @@ module NETSNMP
           { oid: oid, value: val_asn }
         end
 
+        # If a wrong authentication password is set, we can receive a Report PDU (type 8) with only one varbind (usmStatsWrongDigests)
+        error_status = 16 if type == 8 && varbs.first[:oid] == "1.3.6.1.6.3.15.1.1.5.0"
+
         new(type: type, headers: [version, community],
             error_status: error_status,
             error_index: error_index,
@@ -147,7 +150,7 @@ module NETSNMP
                 when 13 then "Resource unavailable"
                 when 14 then "Commit failed"
                 when 15 then "Undo Failed"
-                when 16 then "Authorization Error"
+                when 16 then "Authorization Error (incorrect password, communinty or key)"
                 when 17 then "Not Writable"
                 when 18 then "Inconsistent Name"
                 else

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -159,6 +159,13 @@ RSpec.describe NETSNMP::Client do
       end
     end
     context "with an auth priv policy" do
+      specify "whith wrong auth password and wrong encrypting password" do
+        options = { username: "authprivmd5des", auth_password: "wrongpassword",
+                    auth_protocol: :md5, priv_password: "wrongpassword",
+                    priv_protocol: :des, host: SNMPHOST, port: SNMPPORT }
+        expect { described_class.new(**options).get(oid: get_oid) }.to raise_error(NETSNMP::Error)
+      end
+
       context "auth in md5, encrypting in des" do
         let(:user_options) do
           { username: "authprivmd5des", auth_password: "maplesyrup",


### PR DESCRIPTION
When a bad password is set the device can return a report PDU containing only one varbind, usmStatsWrongDigests.

>    An SNMP engine that receives a reportPDU may use it to determine what
   kind of problem was detected by the remote SNMP engine.  It can do so
   based on the error counter included as the first (and only) varBind
   of the reportPDU.  Based on the detected error, the SNMP engine may
   try to send a corrected SNMP message.  If that is not possible, it
   may pass an indication of the error to the application on whose
   behalf the failed SNMP request was issued.

See https://datatracker.ietf.org/doc/html/rfc3412#section-6.4

Resolve #50 