### PR TITLE
Fix msgAuthenticationParameters for probe snmp v3 requests

### DIFF
--- a/lib/netsnmp/v3_session.rb
+++ b/lib/netsnmp/v3_session.rb
@@ -63,7 +63,7 @@ module NETSNMP
                                                  username: @security_parameters.username)
       pdu = ScopedPDU.build(:get)
       log { "sending probe..." }
-      encoded_report_pdu = @message_serializer.encode(pdu, security_parameters: report_sec_params)
+      encoded_report_pdu = @message_serializer.encode(pdu, security_parameters: report_sec_params, require_authentication: false)
 
       encoded_response_pdu = @transport.send(encoded_report_pdu)
 

--- a/sig/message.rbs
+++ b/sig/message.rbs
@@ -12,12 +12,12 @@ module NETSNMP
 
     def decode: (String stream, security_parameters: SecurityParameters) -> [ScopedPDU, String, Integer, Integer]
 
-    def encode: (ScopedPDU pdu, security_parameters: SecurityParameters, ?engine_boots: Integer, ?engine_time: Integer) -> String
+    def encode: (ScopedPDU pdu, security_parameters: SecurityParameters, ?engine_boots: Integer, ?engine_time: Integer, ?require_authentication: bool) -> String
 
     private
 
     def initialize: (**untyped options) -> void
 
-    def authnone: (Symbol?) -> OpenSSL::ASN1::ASN1Data
+    def authnone: (Symbol?, ?bool) -> OpenSSL::ASN1::ASN1Data
   end
 end


### PR DESCRIPTION
Fixes https://github.com/swisscom/ruby-netsnmp/issues/67

I am not quite sure if this is compliant with the RFCs, those are really hard to read.